### PR TITLE
Fix state check

### DIFF
--- a/SIT.Manager.Avalonia/ViewModels/ServerPageViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/ServerPageViewModel.cs
@@ -100,7 +100,7 @@ namespace SIT.Manager.Avalonia.ViewModels
 
         [RelayCommand]
         private void StartServer() {
-            if (_akiServerService.State == RunningState.NotRunning) {
+            if (_akiServerService.State != RunningState.Running) {
                 if (_akiServerService.IsUnhandledInstanceRunning()) {
                     AddConsole("SPT-AKI is currently running. Please close any running instance of SPT-AKI.");
                     return;


### PR DESCRIPTION
If state was set to `StoppedUnexpectedly` it would fail this conditional and attempt to stop the server. Fixes #8 