### PR TITLE
Enable trimming on publish to reduce size of binary

### DIFF
--- a/SIT.Manager.Avalonia.Desktop/SIT.Manager.Avalonia.Desktop.csproj
+++ b/SIT.Manager.Avalonia.Desktop/SIT.Manager.Avalonia.Desktop.csproj
@@ -5,10 +5,12 @@
 		<Nullable>enable</Nullable>
 		<OutputType>WinExe</OutputType>
 		<PublishSingleFile>true</PublishSingleFile>
+		<PublishTrimmed>True</PublishTrimmed>
 		<SelfContained>true</SelfContained>
 		<!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
 		One for Windows with net7.0-windows TFM, one for MacOS with net7.0-macos and one with net7.0 TFM for Linux.-->
 		<TargetFramework>net7.0</TargetFramework>
+		<TrimMode>link</TrimMode>
 	</PropertyGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
Thinking ahead it's probably an idea to enable this, but we don't have to merge it for a while.